### PR TITLE
Using the Context Holder approach for Namespaces instead of ThreadLocal

### DIFF
--- a/src/main/java/io/openepcis/convert/collector/JsonEPCISEventCollector.java
+++ b/src/main/java/io/openepcis/convert/collector/JsonEPCISEventCollector.java
@@ -39,11 +39,12 @@ public class JsonEPCISEventCollector implements EPCISEventCollector<OutputStream
   private final JsonGenerator jsonGenerator;
   private boolean jsonEventSeparator;
 
-  private final DefaultJsonSchemaNamespaceURIResolver defaultJsonSchemaNamespaceURIResolver =
-      DefaultJsonSchemaNamespaceURIResolver.getInstance();
+  private DefaultJsonSchemaNamespaceURIResolver namespaceResolver;
 
   public JsonEPCISEventCollector(OutputStream stream) {
     this.stream = stream;
+    this.namespaceResolver = DefaultJsonSchemaNamespaceURIResolver.getContext();
+
     // Create the final JSON-LD with Header and event information
     try {
       jsonGenerator = new JsonFactory().createGenerator(this.stream).useDefaultPrettyPrinter();
@@ -92,13 +93,9 @@ public class JsonEPCISEventCollector implements EPCISEventCollector<OutputStream
       jsonGenerator.writeStartArray();
       jsonGenerator.writeString(EPCISVersion.getDefaultJSONContext());
 
-      // Modify the Namespaces so trailing / or : is added and default values are removed
-      defaultJsonSchemaNamespaceURIResolver.getInstance().modifyDocumentNamespaces();
-
       // Get all the stored namespaces from jsonNamespaces
-      defaultJsonSchemaNamespaceURIResolver
-          .getInstance()
-          .getModifiedNamespaces()
+      namespaceResolver
+          .getDocumentNamespaces()
           .forEach(
               (key, value) -> {
                 try {
@@ -112,9 +109,6 @@ public class JsonEPCISEventCollector implements EPCISEventCollector<OutputStream
                 }
               });
       jsonGenerator.writeEndArray();
-
-      // Reset the modified namespaces
-      defaultJsonSchemaNamespaceURIResolver.getInstance().resetModifiedNamespaces();
 
       // Write Other header fields of JSON
       jsonGenerator.writeStringField(EPCIS.TYPE, EPCIS.EPCIS_DOCUMENT);
@@ -179,13 +173,9 @@ public class JsonEPCISEventCollector implements EPCISEventCollector<OutputStream
       jsonGenerator.writeStartArray();
       jsonGenerator.writeString(EPCISVersion.getDefaultJSONContext());
 
-      // Modify the Namespaces so trailing / or : is added and default values are removed
-      defaultJsonSchemaNamespaceURIResolver.getInstance().modifyEventNamespaces();
-
       // Get all the stored namespaces from jsonNamespaces
-      defaultJsonSchemaNamespaceURIResolver
-          .getInstance()
-          .getModifiedNamespaces()
+      namespaceResolver
+          .getEventNamespaces()
           .forEach(
               (key, value) -> {
                 try {
@@ -201,10 +191,7 @@ public class JsonEPCISEventCollector implements EPCISEventCollector<OutputStream
       jsonGenerator.writeEndArray();
 
       // Reset the event namespaces
-      defaultJsonSchemaNamespaceURIResolver.getInstance().resetEventNamespaces();
-
-      // Reset the modified namespaces
-      defaultJsonSchemaNamespaceURIResolver.getInstance().resetModifiedNamespaces();
+      namespaceResolver.resetEventNamespaces();
 
       // Add comma to separate the context and serialized event
       jsonGenerator.writeRaw(",");

--- a/src/main/java/io/openepcis/convert/json/JsonToXmlConverter.java
+++ b/src/main/java/io/openepcis/convert/json/JsonToXmlConverter.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.openepcis.constants.EPCIS;
 import io.openepcis.convert.EventsConverter;
 import io.openepcis.convert.collector.EventHandler;
+import io.openepcis.convert.collector.XmlEPCISEventCollector;
 import io.openepcis.convert.exception.FormatConverterException;
 import io.openepcis.convert.util.IndentingXMLStreamWriter;
 import io.openepcis.convert.util.NonEPCISNamespaceXMLStreamWriter;
@@ -160,7 +161,6 @@ public class JsonToXmlConverter implements EventsConverter {
           || jsonParser.getText().equals(EPCIS.EVENT_ID))) {
         if (jsonParser.getCurrentName() != null
             && jsonParser.getCurrentName().equalsIgnoreCase(EPCIS.CONTEXT)) {
-
           // Read the context value only if the value is of type array else skip to add only string
           if (jsonParser.nextToken() == JsonToken.START_ARRAY) {
             // Loop until end of the Array to obtain Context elements
@@ -206,6 +206,14 @@ public class JsonToXmlConverter implements EventsConverter {
       } catch (Exception e) {
         // Loop until the start of the EPCIS EventList array and prepare the XML header elements
         while (!jsonParser.getText().equals(EPCIS.EVENT_LIST_IN_CAMEL_CASE)) {
+
+          // If the element is type then accordingly set the value EPCISDocument/EPCISQueryDocument
+          if (jsonParser.getCurrentName().equals(EPCIS.TYPE)) {
+            // Set for EPCISDocument or EPCISQueryDocument for adding the header elements
+            XmlEPCISEventCollector.setEPCISDocument(
+                jsonParser.getText().equalsIgnoreCase(EPCIS.EPCIS_DOCUMENT) ? true : false);
+          }
+
           if ((jsonParser.getCurrentToken() == JsonToken.VALUE_STRING
                   || jsonParser.getCurrentToken() == JsonToken.VALUE_NUMBER_FLOAT)
               && (jsonParser.getCurrentName().equalsIgnoreCase(EPCIS.SCHEMA_VERSION)

--- a/src/main/java/io/openepcis/convert/xml/XmlToJsonConverter.java
+++ b/src/main/java/io/openepcis/convert/xml/XmlToJsonConverter.java
@@ -53,6 +53,8 @@ public class XmlToJsonConverter implements EventsConverter {
 
   private final JAXBContext jaxbContext;
 
+  private DefaultJsonSchemaNamespaceURIResolver namespaceResolver;
+
   public XmlToJsonConverter(final JAXBContext jaxbContext) {
     this.jaxbContext = jaxbContext;
   }
@@ -69,6 +71,8 @@ public class XmlToJsonConverter implements EventsConverter {
                     new EPCISNamespacePrefixMapper());
               }
             }));
+
+    this.namespaceResolver = DefaultJsonSchemaNamespaceURIResolver.getContext();
   }
 
   /**
@@ -119,7 +123,7 @@ public class XmlToJsonConverter implements EventsConverter {
       boolean isDocument = false;
 
       // Clear the namespaces before reading the document
-      DefaultJsonSchemaNamespaceURIResolver.getInstance().resetAllNamespaces();
+      namespaceResolver.resetAllNamespaces();
 
       // Jackson instance to convert the unmarshalled event to JSON
       final ObjectMapper objectMapper =
@@ -225,10 +229,9 @@ public class XmlToJsonConverter implements EventsConverter {
                     // default
                     if (!Arrays.asList(Constants.PROTECTED_TERMS_OF_CONTEXT)
                         .contains(xmlStreamReader.getNamespacePrefix(namespaceIndex))) {
-                      DefaultJsonSchemaNamespaceURIResolver.getInstance()
-                          .populateDocumentNamespaces(
-                              xmlStreamReader.getNamespaceURI(namespaceIndex),
-                              xmlStreamReader.getNamespacePrefix(namespaceIndex));
+                      namespaceResolver.populateDocumentNamespaces(
+                          xmlStreamReader.getNamespaceURI(namespaceIndex),
+                          xmlStreamReader.getNamespacePrefix(namespaceIndex));
                     }
                   });
 

--- a/src/test/java/com/io/openepcis/convert/JsonToXmlTest.java
+++ b/src/test/java/com/io/openepcis/convert/JsonToXmlTest.java
@@ -171,4 +171,65 @@ public class JsonToXmlTest {
       // ignored
     }
   }
+
+  /*
+     Tests for EPCISQueryDocument conversion from JSON to XML
+  */
+  @Test
+  public void combinationOfDifferentEventsTest() throws Exception {
+    inputStream =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/JSON/Query/Combination_of_different_event.json");
+    final EventHandler handler =
+        new EventHandler(new EventValidator(), new XmlEPCISEventCollector(byteArrayOutputStream));
+    new JsonToXmlConverter().convert(inputStream, handler);
+    Assert.assertTrue(byteArrayOutputStream.toString().length() > 0);
+  }
+
+  @Test
+  public void jumbledFieldsOrderTest() throws Exception {
+    inputStream =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/JSON/Query/JumbledFieldsOrder.json");
+    final EventHandler handler =
+        new EventHandler(new EventValidator(), new XmlEPCISEventCollector(byteArrayOutputStream));
+    new JsonToXmlConverter().convert(inputStream, handler);
+    Assert.assertTrue(byteArrayOutputStream.toString().length() > 0);
+  }
+
+  @Test
+  public void objectEventWithAllPossibleFieldsTest() throws Exception {
+    inputStream =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/JSON/Query/ObjectEventWithAllPossibleFields.json");
+    final EventHandler handler =
+        new EventHandler(new EventValidator(), new XmlEPCISEventCollector(byteArrayOutputStream));
+    new JsonToXmlConverter().convert(inputStream, handler);
+    Assert.assertTrue(byteArrayOutputStream.toString().length() > 0);
+  }
+
+  @Test
+  public void sensorDataWithCombinedEventsTest() throws Exception {
+    inputStream =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/JSON/Query/SensorData_with_combined_events.json");
+    final InputStream convertedDocument =
+        new VersionTransformer()
+            .convert(
+                inputStream,
+                EPCISFormat.JSON_LD,
+                EPCISVersion.VERSION_2_0_0,
+                EPCISFormat.XML,
+                EPCISVersion.VERSION_2_0_0);
+    Assert.assertTrue((IOUtils.toString(convertedDocument, StandardCharsets.UTF_8).length() > 00));
+    try {
+      convertedDocument.close();
+    } catch (IOException ignore) {
+      // ignored
+    }
+  }
 }

--- a/src/test/java/com/io/openepcis/convert/JsonToXmlTest.java
+++ b/src/test/java/com/io/openepcis/convert/JsonToXmlTest.java
@@ -94,7 +94,6 @@ public class JsonToXmlTest {
         new EventHandler(null, new XmlEPCISEventCollector(byteArrayOutputStream));
     new JsonToXmlConverter().convert(inputStream, handler);
     Assert.assertTrue(byteArrayOutputStream.size() > 0);
-    // System.out.println(byteArrayOutputStream);
   }
 
   // Test the conversion of single EPCIS event in JSON -> XML
@@ -165,7 +164,7 @@ public class JsonToXmlTest {
                 EPCISVersion.VERSION_2_0_0,
                 EPCISFormat.XML,
                 EPCISVersion.VERSION_2_0_0);
-    Assert.assertTrue((IOUtils.toString(convertedDocument, StandardCharsets.UTF_8).length() > 0));
+    Assert.assertTrue((IOUtils.toString(convertedDocument, StandardCharsets.UTF_8).length() > 00));
     try {
       convertedDocument.close();
     } catch (IOException ignore) {

--- a/src/test/java/com/io/openepcis/convert/XmlToJsonTest.java
+++ b/src/test/java/com/io/openepcis/convert/XmlToJsonTest.java
@@ -253,4 +253,60 @@ public class XmlToJsonTest {
       // ignored
     }
   }
+
+  /*
+     Tests for EPCISQueryDocument conversion from JSON to XML
+  */
+  @Test
+  public void combinationOfDifferentEventsTest() throws Exception {
+    inputStream =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/XML/Query/Combination_of_different_event.xml");
+    final EventHandler handler =
+        new EventHandler(new EventValidator(), new JsonEPCISEventCollector(byteArrayOutputStream));
+    new XmlToJsonConverter().convert(inputStream, handler);
+    Assert.assertTrue(byteArrayOutputStream.toString().length() > 0);
+  }
+
+  @Test
+  public void jumbledFieldsOrderTest() throws Exception {
+    inputStream =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/XML/Query/JumbledFieldsOrder.xml");
+    final EventHandler handler =
+        new EventHandler(new EventValidator(), new JsonEPCISEventCollector(byteArrayOutputStream));
+    new XmlToJsonConverter().convert(inputStream, handler);
+    Assert.assertTrue(byteArrayOutputStream.toString().length() > 0);
+  }
+
+  @Test
+  public void objectEventWithAllPossibleFieldsTest() throws Exception {
+    inputStream =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/XML/Query/ObjectEvent_all_possible_fields.xml");
+    final EventHandler handler =
+        new EventHandler(new EventValidator(), new JsonEPCISEventCollector(byteArrayOutputStream));
+    new XmlToJsonConverter().convert(inputStream, handler);
+    Assert.assertTrue(byteArrayOutputStream.toString().length() > 0);
+  }
+
+  @Test
+  public void sensorDataWithCombinedEventsTest() throws Exception {
+    inputStream =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("2.0/EPCIS/XML/Query/SensorData_with_combined_events.xml");
+    final InputStream convertedDocument =
+        versionTransformer.convert(
+            inputStream, EPCISFormat.XML, EPCISFormat.JSON_LD, EPCISVersion.VERSION_2_0_0);
+    Assert.assertTrue((IOUtils.toString(convertedDocument, StandardCharsets.UTF_8).length() > 0));
+    try {
+      convertedDocument.close();
+    } catch (IOException ignore) {
+      // ignored
+    }
+  }
 }


### PR DESCRIPTION
Based on the changes to [openepcis-models](https://github.com/openepcis/openepcis-models) where the namespaces storing approach was enhanced using the context holder approach instead of the ThreadLocal approach. This required the changes in document converter tool. This PR will contain the changes based on it.

Kindly request you to review the changes and approve the PR.