### PR TITLE
Fixing issues while supporting GS1FormatSupport during XML <-> JSON conversion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.openepcis</groupId>
         <artifactId>openepcis-bom</artifactId>
-        <version>0.9.2-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath></relativePath>
     </parent>
 

--- a/src/main/java/io/openepcis/convert/json/JsonToXmlConverter.java
+++ b/src/main/java/io/openepcis/convert/json/JsonToXmlConverter.java
@@ -324,9 +324,9 @@ public class JsonToXmlConverter implements EventsConverter {
           Object xmlSupport = event.xmlSupport();
           if (epcisEventMapper.isPresent()
               && EPCISEvent.class.isAssignableFrom(xmlSupport.getClass())) {
+            final Map<String, String> swappedNamespace = defaultJsonSchemaNamespaceURIResolver.getAllNamespaces().entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
             final EPCISEvent epcisEvent = (EPCISEvent) xmlSupport;
-            epcisEvent.setContextInfo(
-                List.of(defaultJsonSchemaNamespaceURIResolver.getAllNamespaces()));
+            epcisEvent.setContextInfo(List.of(swappedNamespace));
             epcisEvent.setSequenceInEPCISDoc(sequenceInEventList.incrementAndGet());
             xmlSupport = epcisEventMapper.get().apply(xmlSupport);
           }

--- a/src/main/java/io/openepcis/convert/json/JsonToXmlConverter.java
+++ b/src/main/java/io/openepcis/convert/json/JsonToXmlConverter.java
@@ -42,6 +42,8 @@ import java.io.StringWriter;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import jakarta.enterprise.context.RequestScoped;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -214,8 +216,9 @@ public class JsonToXmlConverter implements EventsConverter {
         if (epcisEventMapper.isPresent()
             && EPCISEvent.class.isAssignableFrom(xmlSupport.getClass())) {
           final EPCISEvent epcisEvent = (EPCISEvent) xmlSupport;
-          epcisEvent.setContextInfo(
-              List.of(defaultJsonSchemaNamespaceURIResolver.getAllNamespaces()));
+          //Change the key value to keep key as localname and value as namespaceURI
+          final Map<String, String> swappedNamespace = defaultJsonSchemaNamespaceURIResolver.getAllNamespaces().entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+          epcisEvent.setContextInfo(List.of(swappedNamespace));
           epcisEvent.setSequenceInEPCISDoc(sequenceInEventList.incrementAndGet());
           xmlSupport = epcisEventMapper.get().apply(xmlSupport);
         }

--- a/src/main/java/io/openepcis/convert/json/JsonToXmlConverter.java
+++ b/src/main/java/io/openepcis/convert/json/JsonToXmlConverter.java
@@ -42,7 +42,7 @@ import java.io.StringWriter;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import javax.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.RequestScoped;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;


### PR DESCRIPTION
@sboeckelmann 

This PR will fix the issues associated with missing/invalid namespaces during the conversion of the EPCIS document/event from XML <-> JSON/JSON-LD conversion with various user extensions. Due to these issues, we were unable to convert the document during the conversion with GS1FormatSupport ("Always_GS1_digital_Link", "always_web_uri", etc.). Also, support the document `schemaVersion` detection for the endpoint.

Kindly request you to review the changes and approve the PR.