### PR TITLE
OEPCIS-665: Return ProblemResponseBody when exception occurs, instead of plaintext message

### DIFF
--- a/src/main/java/io/openepcis/convert/VersionTransformer.java
+++ b/src/main/java/io/openepcis/convert/VersionTransformer.java
@@ -15,6 +15,8 @@
  */
 package io.openepcis.convert;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openepcis.constants.EPCIS;
 import io.openepcis.constants.EPCISFormat;
 import io.openepcis.constants.EPCISVersion;
@@ -28,8 +30,10 @@ import io.openepcis.convert.util.ChannelUtil;
 import io.openepcis.convert.xml.XMLEventValueTransformer;
 import io.openepcis.convert.xml.XmlToJsonConverter;
 import io.openepcis.convert.xml.XmlVersionTransformer;
+import io.openepcis.model.rest.ProblemResponseBody;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,7 +47,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
 
+@Slf4j
 public class VersionTransformer {
+
+    private final ObjectMapper objectMapper =
+        new ObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 
     private final ExecutorService executorService;
     private final XmlVersionTransformer xmlVersionTransformer;
@@ -289,13 +299,10 @@ public class VersionTransformer {
                             xmlOutputStream.close();
                         } catch (Exception e) {
                             try {
-                                xmlOutputStream.write(e.getMessage().getBytes());
+                                xmlOutputStream.write(objectMapper.writeValueAsBytes(ProblemResponseBody.fromException(e)));
                                 xmlOutputStream.close();
-                            } finally {
-                                throw new FormatConverterException(
-                                        "Exception occurred during the conversion of JSON 2.0 document to XML 2.0 document  : "
-                                                + e.getMessage(),
-                                        e);
+                            } catch (IOException ioe) {
+                                log.warn("Couldn't write or close the stream", ioe);
                             }
                         }
                     });
@@ -324,13 +331,10 @@ public class VersionTransformer {
                             xmlToJsonConverter.convert(inputDocument, handler);
                         } catch (Exception e) {
                             try {
-                                jsonOutputStream.write(e.getMessage().getBytes());
+                                jsonOutputStream.write(objectMapper.writeValueAsBytes(ProblemResponseBody.fromException(e)));
                                 jsonOutputStream.close();
-                            } finally {
-                                throw new FormatConverterException(
-                                        "Exception occurred during the conversion of XML 2.0 document to JSON 2.0 document  : "
-                                                + e.getMessage(),
-                                        e);
+                            }  catch (IOException ioe) {
+                                log.warn("Couldn't write or close the stream", ioe);
                             }
                         }
                     });
@@ -358,13 +362,10 @@ public class VersionTransformer {
                             jsonEventValueTransformer.convert(inputDocument, handler);
                         } catch (Exception e) {
                             try {
-                                jsonOutputStream.write(e.getMessage().getBytes());
+                                jsonOutputStream.write(objectMapper.writeValueAsBytes(ProblemResponseBody.fromException(e)));
                                 jsonOutputStream.close();
-                            } finally {
-                                throw new FormatConverterException(
-                                        "Exception occurred during the conversion of XML 2.0 document to JSON 2.0 document  : "
-                                                + e.getMessage(),
-                                        e);
+                            } catch (IOException ioe) {
+                                log.warn("Couldn't write or close the stream", ioe);
                             }
                         }
                     });
@@ -393,13 +394,10 @@ public class VersionTransformer {
                             xmlOutputStream.close();
                         } catch (Exception e) {
                             try {
-                                xmlOutputStream.write(e.getMessage().getBytes());
+                                xmlOutputStream.write(objectMapper.writeValueAsBytes(ProblemResponseBody.fromException(e)));
                                 xmlOutputStream.close();
-                            } finally {
-                                throw new FormatConverterException(
-                                        "Exception occurred during the conversion of XML document to XML document  : "
-                                                + e.getMessage(),
-                                        e);
+                            } catch (IOException ioe) {
+                                log.warn("Couldn't write or close the stream", ioe);
                             }
                         }
                     });

--- a/src/main/java/io/openepcis/convert/VersionTransformer.java
+++ b/src/main/java/io/openepcis/convert/VersionTransformer.java
@@ -27,6 +27,7 @@ import io.openepcis.convert.exception.FormatConverterException;
 import io.openepcis.convert.json.JSONEventValueTransformer;
 import io.openepcis.convert.json.JsonToXmlConverter;
 import io.openepcis.convert.util.ChannelUtil;
+import io.openepcis.convert.xml.ProblemResponseBodyMarshaller;
 import io.openepcis.convert.xml.XMLEventValueTransformer;
 import io.openepcis.convert.xml.XmlToJsonConverter;
 import io.openepcis.convert.xml.XmlVersionTransformer;
@@ -299,10 +300,12 @@ public class VersionTransformer {
                             xmlOutputStream.close();
                         } catch (Exception e) {
                             try {
-                                xmlOutputStream.write(objectMapper.writeValueAsBytes(ProblemResponseBody.fromException(e)));
+                                ProblemResponseBodyMarshaller.getMarshaller().marshal(ProblemResponseBody.fromException(e), xmlOutputStream);
                                 xmlOutputStream.close();
                             } catch (IOException ioe) {
                                 log.warn("Couldn't write or close the stream", ioe);
+                            } catch (JAXBException ex) {
+                                throw new RuntimeException(ex);
                             }
                         }
                     });
@@ -394,10 +397,12 @@ public class VersionTransformer {
                             xmlOutputStream.close();
                         } catch (Exception e) {
                             try {
-                                xmlOutputStream.write(objectMapper.writeValueAsBytes(ProblemResponseBody.fromException(e)));
+                                ProblemResponseBodyMarshaller.getMarshaller().marshal(ProblemResponseBody.fromException(e), xmlOutputStream);
                                 xmlOutputStream.close();
                             } catch (IOException ioe) {
                                 log.warn("Couldn't write or close the stream", ioe);
+                            } catch (JAXBException ex) {
+                                throw new RuntimeException(ex);
                             }
                         }
                     });

--- a/src/main/java/io/openepcis/convert/exception/FormatConverterException.java
+++ b/src/main/java/io/openepcis/convert/exception/FormatConverterException.java
@@ -15,8 +15,6 @@
  */
 package io.openepcis.convert.exception;
 
-import io.openepcis.model.rest.ProblemResponseBody;
-
 import java.io.Serial;
 
 /**

--- a/src/main/java/io/openepcis/convert/exception/FormatConverterException.java
+++ b/src/main/java/io/openepcis/convert/exception/FormatConverterException.java
@@ -15,6 +15,8 @@
  */
 package io.openepcis.convert.exception;
 
+import io.openepcis.model.rest.ProblemResponseBody;
+
 import java.io.Serial;
 
 /**
@@ -42,4 +44,5 @@ public class FormatConverterException extends RuntimeException {
   public FormatConverterException(Throwable cause) {
     super(cause);
   }
+
 }

--- a/src/main/java/io/openepcis/convert/xml/ProblemResponseBodyMarshaller.java
+++ b/src/main/java/io/openepcis/convert/xml/ProblemResponseBodyMarshaller.java
@@ -1,0 +1,25 @@
+package io.openepcis.convert.xml;
+
+import io.openepcis.model.rest.ProblemResponseBody;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+
+public class ProblemResponseBodyMarshaller {
+
+    private static Marshaller marshaller;
+
+    static {
+        try {
+            JAXBContext context = JAXBContext.newInstance(ProblemResponseBody.class);
+            marshaller = context.createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        } catch (JAXBException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static Marshaller getMarshaller() {
+        return marshaller;
+    }
+}


### PR DESCRIPTION
- Add ObjectMapper in VersionTransformer to generate ProblemResponseBody's JSON representation to return.