### PR TITLE
GEN-315: Migrate to use the new openepcis-digital-link-converter-core instead of old openepcis-epc-digitallink-translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This project relies on a series of dependencies managed centrally to ensure cons
 - **io.openepcis.quarkus:quarkus-openepcis-model**: The model classes for EPCIS entities within the Quarkus framework.
 - **io.openepcis.quarkus:quarkus-openepcis-model-deployment**: Deployment-specific configurations for the EPCIS model in Quarkus.
 - **xalan:xalan** and **xalan:serializer**: Libraries for XML processing and transformation.
-- **io.openepcis:openepcis-epc-digitallink-translator**: Utilities for converting EPC identifiers between URN and WebURI formats.
+- **io.openepcis:openepcis-digital-link-converter-core**: Utilities for converting EPC identifiers between URN and WebURI formats.
 - **io.openepcis:openepcis-repository-common**: Common repository utilities supporting URN to WebURI conversions.
 - **io.openepcis:openepcis-test-resources**: Test resources for ensuring the quality and correctness of the conversion logic.
 

--- a/core/src/main/java/io/openepcis/converter/common/IdentifierConverterUtil.java
+++ b/core/src/main/java/io/openepcis/converter/common/IdentifierConverterUtil.java
@@ -16,7 +16,8 @@
 package io.openepcis.converter.common;
 
 import io.openepcis.converter.exception.FormatConverterException;
-import io.openepcis.epc.translator.util.ConverterUtil;
+import io.openepcis.identifiers.converter.util.ConverterUtil;
+
 import java.util.Map;
 
 public class IdentifierConverterUtil {

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
             <!-- Converting the EPCIS Identifiers URN <-> WebURI -->
             <dependency>
                 <groupId>io.openepcis</groupId>
-                <artifactId>openepcis-epc-digitallink-translator</artifactId>
+                <artifactId>openepcis-digital-link-converter-core</artifactId>
                 <version>${project.parent.version}</version>
             </dependency>
 

--- a/service/converter-service-rest/pom.xml
+++ b/service/converter-service-rest/pom.xml
@@ -120,7 +120,7 @@
         <!-- Converting the EPCIS Identifiers URN <-> WebURI -->
         <dependency>
             <groupId>io.openepcis</groupId>
-            <artifactId>openepcis-epc-digitallink-translator</artifactId>
+            <artifactId>openepcis-digital-link-converter-core</artifactId>
         </dependency>
 
         <!-- repository common for URN to WebURI support -->

--- a/service/converter-service-servlet/pom.xml
+++ b/service/converter-service-servlet/pom.xml
@@ -57,7 +57,7 @@
         <!-- Converting the EPCIS Identifiers URN <-> WebURI -->
         <dependency>
             <groupId>io.openepcis</groupId>
-            <artifactId>openepcis-epc-digitallink-translator</artifactId>
+            <artifactId>openepcis-digital-link-converter-core</artifactId>
         </dependency>
 
         <!-- repository common for URN to WebURI support -->


### PR DESCRIPTION
@sboeckelmann 

As we have recently developed a new application for the `openepcis-digital-link-toolkit-build`, This PR contains the migration from the old `openepcis-epc-digitallink-translator` to the latest `openepcis-digital-link-converter-core`. 

Could you please review the PR and approve the changes?