### PR TITLE
GEN-323: fix issues found during the capture of xml documents with noop storage

### DIFF
--- a/core/src/main/java/io/openepcis/converter/VersionTransformer.java
+++ b/core/src/main/java/io/openepcis/converter/VersionTransformer.java
@@ -144,11 +144,15 @@ public class VersionTransformer {
       throws UnsupportedOperationException, IOException {
 
     final BufferedInputStream inputDocument = new BufferedInputStream(in);
-    // Checking if mediaType is JSON_LD, and detecting version conditionally
-    EPCISVersion fromVersion =
-        EPCISFormat.JSON_LD.equals(conversion.fromMediaType())
-            ? EPCISVersion.VERSION_2_0_0
-            : versionDetector(inputDocument, conversion);
+    EPCISVersion fromVersion;
+    try{
+      // Checking if mediaType is JSON_LD, and detecting version conditionally
+      fromVersion = EPCISFormat.JSON_LD.equals(conversion.fromMediaType()) ? EPCISVersion.VERSION_2_0_0 : versionDetector(inputDocument, conversion);
+    }catch (Exception e){
+        throw new FormatConverterException(e.getMessage(), e);
+    }
+
+
     InputStream inputStream = inputDocument;
     // If version detected, result won't be null, thus do InputStream operations
     final PipedInputStream pipe = new PipedInputStream();


### PR DESCRIPTION
@sboeckelmann 

Making some minor changes to the streaming of the XML events using XMLStreamReader and returning the exception instead of swallowing. This ensures to fix the issues observed during the XML capture and also if any exceptions occur during the conversion, they will be sent to the client.

Kindly request that you to review the changes and approve the PR.

Reason for modification:
* During the capture of the XML document, there was an issue with advancing to the next element using the XMLStreamReader; now it will always advance to the next element.
* During the capture of an invalid EPCIS 1.1 XML document, the exception or failure messages were not shown to the user as the exception handling was missing. Hence, with this addition, they should be able to see the exception and correct it.
