### PR TITLE
Java 25 / Quarkus 3.33 LTS, Lombok removed

### DIFF
--- a/.github/workflows/maven-cli.yml
+++ b/.github/workflows/maven-cli.yml
@@ -18,10 +18,10 @@ jobs:
       - name: checkout from git
         uses: actions/checkout@v3
 
-      - name: Set up GraalVM 21
+      - name: Set up GraalVM 25
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'graalvm-community'
 
       - id: run_sonarqube

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -24,10 +24,10 @@ jobs:
         id: builder
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up GraalVM 21
+      - name: Set up GraalVM 25
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'graalvm-community'
           cache: maven
           server-id: openepcis-ossrh
@@ -128,10 +128,10 @@ jobs:
         id: builder
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up GraalVM 21
+      - name: Set up GraalVM 25
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'graalvm-community'
           cache: maven
 
@@ -148,7 +148,7 @@ jobs:
             -Dquarkus.container-image.build=true \
             -Dquarkus.container-image.registry=ghcr.io \
             -Dquarkus.container-image.group=openepcis \
-            -Dquarkus.jib.base-jvm-image=eclipse-temurin:21-jre-alpine \
+            -Dquarkus.jib.base-jvm-image=eclipse-temurin:25-jre-alpine \
             -Dquarkus.container-image.additional-tags=latest-amd64,${GIT_TAG_NAME}-amd64 \
             -Dquarkus.jib.platforms=linux/amd64 
 
@@ -160,7 +160,7 @@ jobs:
             -Dquarkus.container-image.build=true \
             -Dquarkus.container-image.registry=ghcr.io \
             -Dquarkus.container-image.group=openepcis \
-            -Dquarkus.jib.base-jvm-image=eclipse-temurin:21-jre-alpine \
+            -Dquarkus.jib.base-jvm-image=eclipse-temurin:25-jre-alpine \
             -Dquarkus.container-image.additional-tags=latest-arm64,${GIT_TAG_NAME}-arm64 \
             -Dquarkus.jib.platforms=linux/arm64/v8
 
@@ -218,10 +218,10 @@ jobs:
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Set up GraalVM 21
+      - name: Set up GraalVM 25
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'graalvm-community'
           cache: maven
 
@@ -328,7 +328,7 @@ jobs:
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'graalvm-community'
           native-image-job-reports: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,11 +107,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- JAXB Annotations Dependencies START -->
         <dependency>

--- a/core/src/main/java/io/openepcis/converter/json/JsonEventParser.java
+++ b/core/src/main/java/io/openepcis/converter/json/JsonEventParser.java
@@ -46,29 +46,19 @@ import java.util.stream.Collectors;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.jaxb.MarshallerProperties;
 
-@Slf4j
 public abstract class JsonEventParser {
-
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(JsonEventParser.class);
   private static final XMLOutputFactory XML_OUTPUT_FACTORY = XMLOutputFactory.newInstance();
   protected final ConversionNamespaceContext nsContext;
   protected final ContextProcessor contextProcessor = ContextProcessor.getInstance();
-
   protected Optional<BiFunction<Object, List<Object>, Object>> epcisEventMapper = Optional.empty();
-
   // Variable to ensure whether provided InputStream is EPCIS document or single event
   boolean isDocument = false;
-
   // To read the JSON-LD events using the Jackson
-  protected final ObjectMapper objectMapper =
-      new ObjectMapper()
-          .registerModule(
-              new SimpleModule()
-                  .addDeserializer(JsonNode.class, new JsonNodeDupeFieldHandlingDeserializer()))
-          .registerModule(new JavaTimeModule());
+  protected final ObjectMapper objectMapper = new ObjectMapper().registerModule(new SimpleModule().addDeserializer(JsonNode.class, new JsonNodeDupeFieldHandlingDeserializer())).registerModule(new JavaTimeModule());
 
   public JsonEventParser(ConversionNamespaceContext nsContext) {
     this.nsContext = nsContext;
@@ -76,22 +66,16 @@ public abstract class JsonEventParser {
 
   protected void validateJsonStream(InputStream jsonStream) {
     if (jsonStream == null) {
-      throw new FormatConverterException(
-          "Unable to convert the events from JSON - XML as InputStream contain any values");
+      throw new FormatConverterException("Unable to convert the events from JSON - XML as InputStream contain any values");
     }
   }
 
-  protected EPCISEvent processSingleEvent(AtomicInteger sequenceInEventList, JsonParser jsonParser)
-      throws IOException {
+  protected EPCISEvent processSingleEvent(AtomicInteger sequenceInEventList, JsonParser jsonParser) throws IOException {
     XmlSupportExtension singleEvent = objectMapper.readValue(jsonParser, XmlSupportExtension.class);
-
     EPCISEvent event = (EPCISEvent) singleEvent.xmlSupport();
     if (epcisEventMapper.isPresent()) {
       // Change the key value to keep key as localname and value as namespaceURI
-      final Map<String, String> swappedNamespace = nsContext != null
-          ? nsContext.getAllNamespaces().entrySet().stream()
-              .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey))
-          : Map.of();
+      final Map<String, String> swappedNamespace = nsContext != null ? nsContext.getAllNamespaces().entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey)) : Map.of();
       // event.setContextInfo(!swappedNamespace.isEmpty() ? List.of(swappedNamespace) : null);
       event.getOpenEPCISExtension().setSequenceInEPCISDoc(sequenceInEventList.incrementAndGet());
       return (EPCISEvent) epcisEventMapper.get().apply(event, List.of(swappedNamespace));
@@ -101,44 +85,27 @@ public abstract class JsonEventParser {
 
   // Parse the @context in JSON document and read the values and store the elements for document
   // level
-  protected void collectNameSpaceAndContextValues(
-      JsonParser jsonParser, final Map<String, String> contextValues) throws IOException {
+  protected void collectNameSpaceAndContextValues(JsonParser jsonParser, final Map<String, String> contextValues) throws IOException {
     // Loop over the jsonParser until reaching the type : EPCISDocument or eventId field at document
     // level
-    while (!(EPCIS.TYPE.equals(jsonParser.getText())
-        || EPCIS.EVENT_ID.equals(jsonParser.getText()))) {
-
+    while (!(EPCIS.TYPE.equals(jsonParser.getText()) || EPCIS.EVENT_ID.equals(jsonParser.getText()))) {
       // If values are present before context, store as metadata in contextValues and add as
       // attributes to epcis:EPCISDocument in XML
-      if (StringUtils.isNotBlank(jsonParser.currentName())
-          && StringUtils.isNotBlank(jsonParser.getText())
-          && !EPCIS.CONTEXT.equalsIgnoreCase(jsonParser.currentName())) {
+      if (StringUtils.isNotBlank(jsonParser.currentName()) && StringUtils.isNotBlank(jsonParser.getText()) && !EPCIS.CONTEXT.equalsIgnoreCase(jsonParser.currentName())) {
         contextValues.put(jsonParser.currentName(), jsonParser.getText());
       }
-
       // Read the context value only if the value is of type array else skip to add only string
-      if (jsonParser.currentName() != null
-          && EPCIS.CONTEXT.equalsIgnoreCase(jsonParser.currentName())
-          && jsonParser.nextToken() == JsonToken.START_ARRAY) {
+      if (jsonParser.currentName() != null && EPCIS.CONTEXT.equalsIgnoreCase(jsonParser.currentName()) && jsonParser.nextToken() == JsonToken.START_ARRAY) {
         // Loop until end of the Array to obtain Context elements
         while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
-
           // Get the default context value from the JSON @context using the ContextLogicDelegator
           // find if its custom context or Default GS1 context
           if (jsonParser.currentToken() == JsonToken.VALUE_STRING && nsContext != null) {
-            contextProcessor.resolveForXmlConversion(
-                Map.of(jsonParser.getText(), jsonParser.getText()),
-                nsContext);
+            contextProcessor.resolveForXmlConversion(Map.of(jsonParser.getText(), jsonParser.getText()), nsContext);
           }
-
           // Store namespace/context with prefix in Map if valid (ignores @ namespaces and default
           // context matching in EPCISNamespacePrefixMapper.EPCIS_NAMESPACE_MAP)
-          if (jsonParser.currentName() != null
-              && jsonParser.currentToken() == JsonToken.VALUE_STRING
-              && !jsonParser.currentName().startsWith("@")
-              && !EPCIS.EPCIS_DEFAULT_NAMESPACES.containsValue(jsonParser.getText())
-              && !EPCIS.GS1_EPCIS_DOMAIN.equalsIgnoreCase(jsonParser.getText())
-              && nsContext != null) {
+          if (jsonParser.currentName() != null && jsonParser.currentToken() == JsonToken.VALUE_STRING && !jsonParser.currentName().startsWith("@") && !EPCIS.EPCIS_DEFAULT_NAMESPACES.containsValue(jsonParser.getText()) && !EPCIS.GS1_EPCIS_DOMAIN.equalsIgnoreCase(jsonParser.getText()) && nsContext != null) {
             // Add namespaces from JSON schema to the map (key: remote URL/URN and value: prefix
             // associated to URL)
             nsContext.populateDocumentNamespaces(jsonParser.getText(), jsonParser.currentName());
@@ -149,24 +116,17 @@ public abstract class JsonEventParser {
     }
   }
 
-  protected void collectDocumentMetaData(
-      final Map<String, String> contextValues,
-      final JsonParser jsonParser,
-      final EventHandler eventHandler)
-      throws IOException {
+  protected void collectDocumentMetaData(final Map<String, String> contextValues, final JsonParser jsonParser, final EventHandler eventHandler) throws IOException {
     boolean isEPCISDocument = false;
-
     // Loop till the eventList and obtain the information at the document level like creationDate,
     // schemaVersion, type etc.
     while (!EPCIS.EVENT_LIST_IN_CAMEL_CASE.equals(jsonParser.getText())) {
-
       // If the element is type then accordingly set the value EPCISDocument/EPCISQueryDocument
       if (EPCIS.TYPE.equals(jsonParser.currentName())) {
         // Set for EPCISDocument or EPCISQueryDocument for adding the header element
         isEPCISDocument = EPCIS.EPCIS_DOCUMENT.equalsIgnoreCase(jsonParser.getText());
         eventHandler.setIsEPCISDocument(isEPCISDocument);
       }
-
       // For EPCISQueryDocument set SubscriptionID and QueryName for XML writing
       if (!isEPCISDocument) {
         if (EPCIS.SUBSCRIPTION_ID.equalsIgnoreCase(jsonParser.currentName())) {
@@ -175,12 +135,7 @@ public abstract class JsonEventParser {
           eventHandler.setQueryName(jsonParser.nextTextValue());
         }
       }
-
-      if ((jsonParser.getCurrentToken() == JsonToken.VALUE_STRING
-              || jsonParser.getCurrentToken() == JsonToken.VALUE_NUMBER_FLOAT)
-          && (EPCIS.SCHEMA_VERSION.equalsIgnoreCase(jsonParser.currentName())
-              || EPCIS.CREATION_DATE.equalsIgnoreCase(jsonParser.currentName()))) {
-
+      if ((jsonParser.getCurrentToken() == JsonToken.VALUE_STRING || jsonParser.getCurrentToken() == JsonToken.VALUE_NUMBER_FLOAT) && (EPCIS.SCHEMA_VERSION.equalsIgnoreCase(jsonParser.currentName()) || EPCIS.CREATION_DATE.equalsIgnoreCase(jsonParser.currentName()))) {
         // Add the elements to target event header
         contextValues.put(jsonParser.currentName(), jsonParser.getText());
       }
@@ -189,101 +144,59 @@ public abstract class JsonEventParser {
   }
 
   // Method which will traverse through the eventList and read event one-by-one
-  protected void eventTraverser(
-      JsonParser jsonParser,
-      ObjectMapper objectMapper,
-      Marshaller marshaller,
-      EventHandler<? extends EPCISEventCollector> eventHandler,
-      boolean isMarshallingRequired)
-      throws IOException, JAXBException, XMLStreamException {
-
+  protected void eventTraverser(JsonParser jsonParser, ObjectMapper objectMapper, Marshaller marshaller, EventHandler<? extends EPCISEventCollector> eventHandler, boolean isMarshallingRequired) throws IOException, JAXBException, XMLStreamException {
     // StringWriter to get the converted XML from marshaller
     final StringWriter xmlEvent = new StringWriter();
     final AtomicInteger sequenceInEventList = new AtomicInteger(0);
-
     // Loop until the end of the EPCIS events file
     while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
-
       // Get the node
       final JsonNode jsonNode = jsonParser.readValueAsTree();
-
       // Check if the JsonNode is valid and contains the values if not throw error for particular
       // event
       if (!(jsonNode == null || jsonNode.get(EPCIS.TYPE) == null)) {
-
         // Based on eventType call different type of class
         XmlSupportExtension event = objectMapper.treeToValue(jsonNode, XmlSupportExtension.class);
-
         // If event has some value then perform the Marshalling and call handling methods based on
         // User input
         if (event != null) {
-
           // Create the XML based on type of incoming event type and store in StringWriter
-
           Object xmlSupport = event.xmlSupport();
-          if (epcisEventMapper.isPresent()
-              && EPCISEvent.class.isAssignableFrom(xmlSupport.getClass())) {
-            final Map<String, String> swappedNamespace = nsContext != null
-                ? nsContext.getAllNamespaces().entrySet().stream()
-                    .collect(
-                        Collectors.toMap(
-                            Map.Entry::getValue,
-                            Map.Entry::getKey,
-                            (existing, replacement) -> existing))
-                : Map.of();
+          if (epcisEventMapper.isPresent() && EPCISEvent.class.isAssignableFrom(xmlSupport.getClass())) {
+            final Map<String, String> swappedNamespace = nsContext != null ? nsContext.getAllNamespaces().entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey, (existing, replacement) -> existing)) : Map.of();
             final EPCISEvent epcisEvent = (EPCISEvent) xmlSupport;
-            epcisEvent
-                .getOpenEPCISExtension()
-                .setSequenceInEPCISDoc(sequenceInEventList.incrementAndGet());
+            epcisEvent.getOpenEPCISExtension().setSequenceInEPCISDoc(sequenceInEventList.incrementAndGet());
             xmlSupport = epcisEventMapper.get().apply(xmlSupport, List.of(swappedNamespace));
           }
-
           if (isMarshallingRequired) {
-            final XMLStreamWriter skipEPCISNamespaceWriter =
-                new NonEPCISNamespaceXMLStreamWriter(
-                    new IndentingXMLStreamWriter(
-                        XML_OUTPUT_FACTORY.createXMLStreamWriter(xmlEvent)));
-
+            final XMLStreamWriter skipEPCISNamespaceWriter = new NonEPCISNamespaceXMLStreamWriter(new IndentingXMLStreamWriter(XML_OUTPUT_FACTORY.createXMLStreamWriter(xmlEvent)));
             // Marshaller properties: Add the custom namespaces instead of the ns1, ns2
-            final Map<String, String> allNamespaces = nsContext != null
-                ? nsContext.getAllNamespaces()
-                : Map.of();
-            marshaller.setProperty(
-                MarshallerProperties.NAMESPACE_PREFIX_MAPPER,
-                allNamespaces);
+            final Map<String, String> allNamespaces = nsContext != null ? nsContext.getAllNamespaces() : Map.of();
+            marshaller.setProperty(MarshallerProperties.NAMESPACE_PREFIX_MAPPER, allNamespaces);
             if (nsContext != null) {
               marshaller.setAdapter(CustomExtensionAdapter.class, new CustomExtensionAdapter(nsContext));
             }
-
             marshaller.marshal(xmlSupport, skipEPCISNamespaceWriter);
-
             // Call the method to check if the event adheres to XSD or write into the OutputStream
             // using the EventHandler
             eventHandler.handler(xmlEvent);
-
           } else {
             // Create the JSON using Jackson ObjectMapper based on type of incoming event type and
             // store
-            final String eventAsJson =
-                objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(xmlSupport);
+            final String eventAsJson = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(xmlSupport);
             eventHandler.handler(eventAsJson);
           }
-
           if (isMarshallingRequired) {
             // Clear the StringWriter for next event
             xmlEvent.getBuffer().setLength(0);
           }
-
           // Reset the namespaces stored for particular event
           if (nsContext != null) {
             nsContext.resetEventNamespaces();
           }
         }
-
       } else {
-        log.error(
-            "Could not find required Event information for the particular event as \"type\" attribute missing, Proceeding to next event from EventList : "
-                + jsonNode);
+        log.error("Could not find required Event information for the particular event as \"type\" attribute missing, Proceeding to next event from EventList : " + jsonNode);
       }
     }
   }

--- a/core/src/main/java/io/openepcis/converter/json/JsonToXmlConverter.java
+++ b/core/src/main/java/io/openepcis/converter/json/JsonToXmlConverter.java
@@ -43,7 +43,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
-import lombok.extern.slf4j.Slf4j;
 import org.eclipse.persistence.jaxb.JAXBContextProperties;
 import org.eclipse.persistence.jaxb.MarshallerProperties;
 
@@ -53,12 +52,9 @@ import org.eclipse.persistence.jaxb.MarshallerProperties;
  * JSON to XML converter for EPCIS events. Do not share an instance across threads. EventsConverter:
  * Public method that will be called by client during the conversions.
  */
-@Slf4j
 @RequestScoped
 public class JsonToXmlConverter extends JsonEventParser implements EventsConverter {
-
   private final JAXBContext jaxbContext;
-
   private static final XMLOutputFactory XML_OUTPUT_FACTORY = XMLOutputFactory.newInstance();
 
   public JsonToXmlConverter(final JAXBContext jaxbContext, final ConversionNamespaceContext nsContext) {
@@ -70,24 +66,17 @@ public class JsonToXmlConverter extends JsonEventParser implements EventsConvert
     this(jaxbContext, new ConversionNamespaceContext());
   }
 
-  private JsonToXmlConverter(
-      final JsonToXmlConverter parent, BiFunction<Object, List<Object>, Object> epcisEventMapper) {
+  private JsonToXmlConverter(final JsonToXmlConverter parent, BiFunction<Object, List<Object>, Object> epcisEventMapper) {
     this(parent.jaxbContext, parent.nsContext);
     this.epcisEventMapper = Optional.ofNullable(epcisEventMapper);
   }
 
   public JsonToXmlConverter() throws JAXBException {
-    this(
-        JAXBContext.newInstance(
-            "io.openepcis.model.epcis",
-            Thread.currentThread().getContextClassLoader(),
-            new HashMap<>() {
-              {
-                put(
-                    JAXBContextProperties.NAMESPACE_PREFIX_MAPPER,
-                    new EPCISNamespacePrefixMapper());
-              }
-            }));
+    this(JAXBContext.newInstance("io.openepcis.model.epcis", Thread.currentThread().getContextClassLoader(), new HashMap<>() {
+      {
+        put(JAXBContextProperties.NAMESPACE_PREFIX_MAPPER, new EPCISNamespacePrefixMapper());
+      }
+    }));
   }
 
   /**
@@ -101,9 +90,7 @@ public class JsonToXmlConverter extends JsonEventParser implements EventsConvert
    * @throws IOException Method throws IOException when error occurred during the conversion.
    */
   @Override
-  public void convert(
-      InputStream jsonStream, EventHandler<? extends EPCISEventCollector> eventHandler)
-      throws IOException, JAXBException {
+  public void convert(InputStream jsonStream, EventHandler<? extends EPCISEventCollector> eventHandler) throws IOException, JAXBException {
     convert(jsonStream, eventHandler, this.jaxbContext);
   }
 
@@ -119,86 +106,56 @@ public class JsonToXmlConverter extends JsonEventParser implements EventsConvert
    * @throws IOException Method throws IOException when error occurred during the conversion.
    */
   @Override
-  public void convert(
-      InputStream jsonStream,
-      EventHandler<? extends EPCISEventCollector> eventHandler,
-      JAXBContext jaxbContext)
-      throws IOException, JAXBException {
-
+  public void convert(InputStream jsonStream, EventHandler<? extends EPCISEventCollector> eventHandler, JAXBContext jaxbContext) throws IOException, JAXBException {
     // Check if InputStream has some content if not then throw appropriate Exception
     validateJsonStream(jsonStream);
-
     // Clear the namespaces before reading the document
     nsContext.resetAllNamespaces();
-
     // Create a Marshaller instance to convert to XML
     final Marshaller marshaller = jaxbContext.createMarshaller();
     // Set Marshalling properties: print formatted XML, exclude <xml> version tag for every event,
     marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
     marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
-
     // Store the information from JSON header for creation of final XML
     final Map<String, String> contextValues = new HashMap<>();
-
     final AtomicInteger sequenceInEventList = new AtomicInteger(0);
-
     // Get the JSON Factory and parser Object
     try (JsonParser jsonParser = new JsonFactory().createParser(jsonStream)) {
-
       // To read the duplicate keys for User Extensions, ILMD and other elements in JSON-LD
       jsonParser.setCodec(objectMapper);
-
       // Check the first element is Object if not then invalid JSON throw error
       if (jsonParser.nextToken() != JsonToken.START_OBJECT) {
-        throw new FormatConverterException(
-            "Invalid JSON-LD file has been provided. JSON-LD file should start with the Object");
+        throw new FormatConverterException("Invalid JSON-LD file has been provided. JSON-LD file should start with the Object");
       }
-
       // Loop until type element to read the Context values and namespaces present in it
       collectNameSpaceAndContextValues(jsonParser, contextValues);
-
       try {
-
         EPCISEvent event = processSingleEvent(sequenceInEventList, jsonParser);
         // Set the namespaces for the marshaller
-        marshaller.setProperty(
-            MarshallerProperties.NAMESPACE_PREFIX_MAPPER,
-            nsContext.getAllNamespaces());
+        marshaller.setProperty(MarshallerProperties.NAMESPACE_PREFIX_MAPPER, nsContext.getAllNamespaces());
         marshaller.setAdapter(CustomExtensionAdapter.class, new CustomExtensionAdapter(nsContext));
-
         // StringWriter to get the converted XML from marshaller
         final StringWriter singleXmlEvent = new StringWriter();
-
-        final XMLStreamWriter skipEPCISNamespaceWriter =
-            new NonEPCISNamespaceXMLStreamWriter(
-                new IndentingXMLStreamWriter(
-                    XML_OUTPUT_FACTORY.createXMLStreamWriter(singleXmlEvent)));
+        final XMLStreamWriter skipEPCISNamespaceWriter = new NonEPCISNamespaceXMLStreamWriter(new IndentingXMLStreamWriter(XML_OUTPUT_FACTORY.createXMLStreamWriter(singleXmlEvent)));
         // Marshaller properties: Add the custom namespaces instead of the ns1, ns2
         marshaller.marshal(event, skipEPCISNamespaceWriter);
-
         // Call the method to check if the event adheres to XSD or write into the OutputStream using
         // the EventHandler
         eventHandler.collectSingleEvent(singleXmlEvent);
       } catch (Exception e) {
         // Loop until the start of the EPCIS EventList array and prepare the XML header elements
         collectDocumentMetaData(contextValues, jsonParser, eventHandler);
-
         // Goto the next token
         jsonParser.nextToken();
-
         // this will prepare document header, epcisBody, eventList elements
         eventHandler.start(contextValues);
-
         // Call the method to loop until the end of the events file
         eventTraverser(jsonParser, objectMapper, marshaller, eventHandler, true);
-
         // Call the End method to close all the header and other tags for the XML file
         eventHandler.end();
-
         // Close the JSON Parser after completing the reading of all contents
         jsonParser.close();
       }
-
     } catch (Exception e) {
       eventHandler.fail(e);
       throw new FormatConverterException("Exception during the reading of JSON-LD file : " + e, e);

--- a/core/src/main/java/io/openepcis/converter/util/ChannelUtil.java
+++ b/core/src/main/java/io/openepcis/converter/util/ChannelUtil.java
@@ -23,15 +23,12 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChannelUtil {
-
   public static void copy(InputStream inputStream, OutputStream outputStream) throws IOException {
-    try (final ReadableByteChannel src = Channels.newChannel(inputStream);
-        final WritableByteChannel dest = Channels.newChannel(outputStream); ) {
+    try (
+      ReadableByteChannel src = Channels.newChannel(inputStream);
+      WritableByteChannel dest = Channels.newChannel(outputStream)) {
       final ByteBuffer buffer = ByteBuffer.allocateDirect(1024);
       while (src.read(buffer) != -1) {
         buffer.flip();
@@ -46,29 +43,30 @@ public class ChannelUtil {
   }
 
   public static Multi<byte[]> toMulti(InputStream inputStream) {
-    return Multi.createFrom()
-        .emitter(
-            em -> {
-              try (final ReadableByteChannel src = Channels.newChannel(inputStream); ) {
-                byte[] bytes;
-                final ByteBuffer buffer = ByteBuffer.allocateDirect(1024);
-                while (src.read(buffer) != -1) {
-                  buffer.flip();
-                  bytes = new byte[buffer.remaining()];
-                  buffer.get(bytes, 0, bytes.length);
-                  em.emit(bytes);
-                  buffer.compact();
-                }
-                buffer.flip();
-                while (buffer.hasRemaining()) {
-                  bytes = new byte[buffer.remaining()];
-                  buffer.get(bytes, 0, bytes.length);
-                  em.emit(bytes);
-                }
-                em.complete();
-              } catch (Exception e) {
-                em.fail(e);
-              }
-            });
+    return Multi.createFrom().emitter(em -> {
+      try (ReadableByteChannel src = Channels.newChannel(inputStream)) {
+        byte[] bytes;
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(1024);
+        while (src.read(buffer) != -1) {
+          buffer.flip();
+          bytes = new byte[buffer.remaining()];
+          buffer.get(bytes, 0, bytes.length);
+          em.emit(bytes);
+          buffer.compact();
+        }
+        buffer.flip();
+        while (buffer.hasRemaining()) {
+          bytes = new byte[buffer.remaining()];
+          buffer.get(bytes, 0, bytes.length);
+          em.emit(bytes);
+        }
+        em.complete();
+      } catch (Exception e) {
+        em.fail(e);
+      }
+    });
+  }
+
+  private ChannelUtil() {
   }
 }

--- a/core/src/main/java/io/openepcis/converter/validator/EventValidator.java
+++ b/core/src/main/java/io/openepcis/converter/validator/EventValidator.java
@@ -33,7 +33,6 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
-import lombok.extern.slf4j.Slf4j;
 import org.xml.sax.SAXException;
 
 /**
@@ -42,27 +41,15 @@ import org.xml.sax.SAXException;
  * respective information's are shown in Log but the information will be added to final
  * OutputStream. If EPCIS event adheres to XSD/JSON-Schema then no information will be logged.
  */
-@Slf4j
 public class EventValidator implements EPCISEventValidator {
-
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(EventValidator.class);
   private final Schema xsdSchema;
-
   private final ObjectMapper objectMapper = new ObjectMapper();
-  private final JsonSchemaFactory validatorFactory =
-      JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
-          .yamlMapper(objectMapper)
-          .build();
+  private final JsonSchemaFactory validatorFactory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7)).yamlMapper(objectMapper).build();
 
   public EventValidator() {
     try {
-      xsdSchema =
-          SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
-              .newSchema(
-                  new StreamSource(
-                      EventValidator.class
-                          .getClassLoader()
-                          .getResourceAsStream("eventSchemas/EPCISEventXSD.xsd")));
-
+      xsdSchema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema(new StreamSource(EventValidator.class.getClassLoader().getResourceAsStream("eventSchemas/EPCISEventXSD.xsd")));
     } catch (SAXException e) {
       throw new FormatConverterException(e);
     }
@@ -75,74 +62,50 @@ public class EventValidator implements EPCISEventValidator {
       try {
         // Create an instance of Validator
         final Validator validator = xsdSchema.newValidator();
-
         // Assign the event to String variable
         final String convertedEvent = event.toString();
-
         // Validate the event against the XSD schema
         validator.validate(new StreamSource(new ByteArrayInputStream(convertedEvent.getBytes())));
-
         // If validation is successful then show the message of success
         log.debug("Event adheres to EPCIS Standard XSD Schema");
       } catch (Exception ex) {
         // If validation fails then show warning message
-        log.warn(
-            "Event Does NOT adhere to EPCIS Standard XSD Schema. However, proceeding to next event from EventList");
+        log.warn("Event Does NOT adhere to EPCIS Standard XSD Schema. However, proceeding to next event from EventList");
       }
     } else if (event instanceof String convertedEvent) {
       // If the event is of String type then its JSON so compare with JSON Schema
-
       try {
         // Get the JSONNode from the Event and what type of event
         final JsonNode parent = objectMapper.readTree(convertedEvent).get(EPCIS.TYPE);
-
         // If the epcisEvent is not null then continue with validation
         if (parent != null && parent.textValue() != null) {
-
           // Get the eventType so accordingly compared with the JSONSchema
           final String epcisEvent = parent.textValue();
-
           String schemaFile = "";
-
           // Based on eventType choose different Schema file for the validation
           switch (epcisEvent) {
             case EPCIS.OBJECT_EVENT -> schemaFile = "/eventSchemas/ObjectEventSchema.json";
-            case EPCIS.AGGREGATION_EVENT ->
-                schemaFile = "/eventSchemas/AggregationEventSchema.json";
-            case EPCIS.TRANSACTION_EVENT ->
-                schemaFile = "/eventSchemas/TransactionEventSchema.json";
-            case EPCIS.TRANSFORMATION_EVENT ->
-                schemaFile = "/eventSchemas/TransformationEventSchema.json";
-            case EPCIS.ASSOCIATION_EVENT ->
-                schemaFile = "/eventSchemas/AssociationEventSchema.json";
-            default ->
-                // If NONE of the EPCIS event type matches
-                log.error(
-                    "JSON event does not match any of EPCIS event. However, proceeding to next event from EventList");
+            case EPCIS.AGGREGATION_EVENT -> schemaFile = "/eventSchemas/AggregationEventSchema.json";
+            case EPCIS.TRANSACTION_EVENT -> schemaFile = "/eventSchemas/TransactionEventSchema.json";
+            case EPCIS.TRANSFORMATION_EVENT -> schemaFile = "/eventSchemas/TransformationEventSchema.json";
+            case EPCIS.ASSOCIATION_EVENT -> schemaFile = "/eventSchemas/AssociationEventSchema.json";
+            default -> 
+            // If NONE of the EPCIS event type matches
+            log.error("JSON event does not match any of EPCIS event. However, proceeding to next event from EventList");
           }
-
           // Get the schema file based on different schema and validate them
-          final JsonSchema jsonSchema =
-              validatorFactory.getSchema(getClass().getResourceAsStream(schemaFile));
-          final Set<ValidationMessage> validationErrors =
-              jsonSchema.validate(objectMapper.readValue((String) event, JsonNode.class));
-
+          final JsonSchema jsonSchema = validatorFactory.getSchema(getClass().getResourceAsStream(schemaFile));
+          final Set<ValidationMessage> validationErrors = jsonSchema.validate(objectMapper.readValue((String) event, JsonNode.class));
           if (validationErrors.isEmpty()) {
             log.debug("Event adheres to EPCIS Standard JSON-LD Schema");
           } else {
-            log.warn(
-                "Event Does NOT adhere to EPCIS Standard JSON-LD Schema. However, proceeding to next event from EventList");
+            log.warn("Event Does NOT adhere to EPCIS Standard JSON-LD Schema. However, proceeding to next event from EventList");
           }
         } else {
-          log.error(
-              "Converted EPCIS Event does not contain \"type\" field so cannot be validated against JSON Schema : {} "
-                  + convertedEvent);
+          log.error("Converted EPCIS Event does not contain \"type\" field so cannot be validated against JSON Schema : {} " + convertedEvent);
         }
       } catch (IOException | ProcessingException e) {
-        throw new FormatConverterException(
-            "Exception occurred during the validation of converted JSON event against the JSON-Schema : "
-                + e,
-            e);
+        throw new FormatConverterException("Exception occurred during the validation of converted JSON event against the JSON-Schema : " + e, e);
       }
     }
   }

--- a/core/src/main/java/io/openepcis/converter/xml/ProblemResponseBodyMarshaller.java
+++ b/core/src/main/java/io/openepcis/converter/xml/ProblemResponseBodyMarshaller.java
@@ -19,11 +19,9 @@ import io.openepcis.model.rest.ProblemResponseBody;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 public class ProblemResponseBodyMarshaller {
-
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ProblemResponseBodyMarshaller.class);
   private static Marshaller marshaller;
 
   static {

--- a/core/src/main/java/io/openepcis/converter/xml/XMLEventParser.java
+++ b/core/src/main/java/io/openepcis/converter/xml/XMLEventParser.java
@@ -37,18 +37,13 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
-@Slf4j
 public abstract class XMLEventParser {
-
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(XMLEventParser.class);
   protected final JAXBContext jaxbContext;
-
   protected final ConversionNamespaceContext nsContext;
-
   protected Optional<BiFunction<Object, List<Object>, Object>> epcisEventMapper = Optional.empty();
-
   protected static final XMLOutputFactory XML_OUTPUT_FACTORY = XMLOutputFactory.newInstance();
 
   public XMLEventParser(JAXBContext jaxbContext, ConversionNamespaceContext nsContext) {
@@ -57,10 +52,9 @@ public abstract class XMLEventParser {
   }
 
   protected void validateXmlEvent(Unmarshaller unmarshaller) throws JAXBException {
-    unmarshaller.setEventHandler(
-        validationEvent -> {
-          throw new FormatConverterException(validationEvent.getMessage());
-        });
+    unmarshaller.setEventHandler(validationEvent -> {
+      throw new FormatConverterException(validationEvent.getMessage());
+    });
   }
 
   protected XMLStreamReader createXmlStreamReader(InputStream xmlStream) throws XMLStreamException {
@@ -82,37 +76,34 @@ public abstract class XMLEventParser {
 
   protected void validateXmlStrem(InputStream xmlStream) {
     if (xmlStream == null) {
-      throw new FormatConverterException(
-          "Unable to convert the events from XML - JSON-LD as InputStream contains NULL values");
+      throw new FormatConverterException("Unable to convert the events from XML - JSON-LD as InputStream contains NULL values");
     }
   }
 
-  protected Object getEvent(XMLStreamReader xmlStreamReader, Unmarshaller unmarshaller)
-      throws JAXBException {
+  protected Object getEvent(XMLStreamReader xmlStreamReader, Unmarshaller unmarshaller) throws JAXBException {
     // Get the event type
     final String epcisEvent = xmlStreamReader.getLocalName();
-
     Object event = null;
     // Based on eventType make unmarshaller call to respective event class
     switch (epcisEvent) {
-      case EPCIS.OBJECT_EVENT ->
-          // Unmarshal the ObjectEvent and Convert it to JSON-LD
-          event = unmarshaller.unmarshal(xmlStreamReader, ObjectEvent.class).getValue();
-      case EPCIS.AGGREGATION_EVENT ->
-          // Unmarshal the AggregationEvent and Convert it to JSON-LD
-          event = unmarshaller.unmarshal(xmlStreamReader, AggregationEvent.class).getValue();
-      case EPCIS.TRANSACTION_EVENT ->
-          // Unmarshal the TransactionEvent and Convert it to JSON-LD
-          event = unmarshaller.unmarshal(xmlStreamReader, TransactionEvent.class).getValue();
-      case EPCIS.TRANSFORMATION_EVENT ->
-          // Unmarshal the TransformationEvent and Convert it to JSON-LD
-          event = unmarshaller.unmarshal(xmlStreamReader, TransformationEvent.class).getValue();
-      case EPCIS.ASSOCIATION_EVENT ->
-          // Unmarshal the AssociationEvent and Convert it to JSON-LD
-          event = unmarshaller.unmarshal(xmlStreamReader, AssociationEvent.class).getValue();
-      default ->
-          // If NONE of the EPCIS event type matches then do not convert and make a note
-          log.error("JSON event does not match any of EPCIS event : {} ", epcisEvent);
+      case EPCIS.OBJECT_EVENT -> 
+      // Unmarshal the ObjectEvent and Convert it to JSON-LD
+      event = unmarshaller.unmarshal(xmlStreamReader, ObjectEvent.class).getValue();
+      case EPCIS.AGGREGATION_EVENT -> 
+      // Unmarshal the AggregationEvent and Convert it to JSON-LD
+      event = unmarshaller.unmarshal(xmlStreamReader, AggregationEvent.class).getValue();
+      case EPCIS.TRANSACTION_EVENT -> 
+      // Unmarshal the TransactionEvent and Convert it to JSON-LD
+      event = unmarshaller.unmarshal(xmlStreamReader, TransactionEvent.class).getValue();
+      case EPCIS.TRANSFORMATION_EVENT -> 
+      // Unmarshal the TransformationEvent and Convert it to JSON-LD
+      event = unmarshaller.unmarshal(xmlStreamReader, TransformationEvent.class).getValue();
+      case EPCIS.ASSOCIATION_EVENT -> 
+      // Unmarshal the AssociationEvent and Convert it to JSON-LD
+      event = unmarshaller.unmarshal(xmlStreamReader, AssociationEvent.class).getValue();
+      default -> 
+      // If NONE of the EPCIS event type matches then do not convert and make a note
+      log.error("JSON event does not match any of EPCIS event : {} ", epcisEvent);
     }
     return event;
   }
@@ -123,28 +114,20 @@ public abstract class XMLEventParser {
       // Use getNamespacesForXml() which returns prefix -> URI format directly
       // This preserves ALL prefixes, even when multiple prefixes map to the same URI
       // (e.g., ns0, ns3, ns4 all mapping to http://example.com/cbvmda/)
-      final Map<String, String> prefixToUri = nsContext != null
-          ? nsContext.getNamespacesForXml()
-          : Map.of();
+      final Map<String, String> prefixToUri = nsContext != null ? nsContext.getNamespacesForXml() : Map.of();
       ev.getOpenEPCISExtension().setSequenceInEPCISDoc(sequenceInEventList.incrementAndGet());
       event = epcisEventMapper.get().apply(event, List.of(prefixToUri));
     }
     return event;
   }
 
-  protected void setSubScriptionIdAndQueryName(
-      EventHandler<? extends EPCISEventCollector> eventHandler,
-      Map<String, String> contextAttributes,
-      XMLStreamReader xmlStreamReader)
-      throws XMLStreamException {
+  protected void setSubScriptionIdAndQueryName(EventHandler<? extends EPCISEventCollector> eventHandler, Map<String, String> contextAttributes, XMLStreamReader xmlStreamReader) throws XMLStreamException {
     if (!eventHandler.isEPCISDocument()) {
       if (xmlStreamReader.getLocalName().equalsIgnoreCase(EPCIS.SUBSCRIPTION_ID)) {
         eventHandler.setSubscriptionID(xmlStreamReader.getElementText());
       } else if (xmlStreamReader.getLocalName().equalsIgnoreCase(EPCIS.QUERY_NAME)) {
         eventHandler.setQueryName(xmlStreamReader.getElementText());
-      } else if (xmlStreamReader
-          .getLocalName()
-          .equalsIgnoreCase(EPCIS.RESULTS_BODY_IN_CAMEL_CASE)) {
+      } else if (xmlStreamReader.getLocalName().equalsIgnoreCase(EPCIS.RESULTS_BODY_IN_CAMEL_CASE)) {
         // For QueryDocument invoke EventHandle Start to create the header information at
         // resultsBody
         eventHandler.start(contextAttributes);
@@ -156,19 +139,14 @@ public abstract class XMLEventParser {
     if (nsContext == null) {
       return;
     }
-
-    IntStream.range(0, xmlStreamReader.getNamespaceCount())
-            .forEach(
-                    namespaceIndex -> {
-                      // Omit the Namespace values which are already present within JSON-LD Context by default and empty namespaces
-                      final String namespacePrefix = xmlStreamReader.getNamespacePrefix(namespaceIndex);
-                      final String namespaceURI = xmlStreamReader.getNamespaceURI(namespaceIndex);
-                      if (StringUtils.isNotBlank(namespacePrefix)
-                              &&  StringUtils.isNotBlank(namespaceURI)
-                              && !EPCIS.PROTECTED_NAMESPACE_URIS.contains(namespaceURI)) {
-                        nsContext.populateDocumentNamespaces(namespaceURI, namespacePrefix);
-                      }
-                    });
+    IntStream.range(0, xmlStreamReader.getNamespaceCount()).forEach(namespaceIndex -> {
+      // Omit the Namespace values which are already present within JSON-LD Context by default and empty namespaces
+      final String namespacePrefix = xmlStreamReader.getNamespacePrefix(namespaceIndex);
+      final String namespaceURI = xmlStreamReader.getNamespaceURI(namespaceIndex);
+      if (StringUtils.isNotBlank(namespacePrefix) && StringUtils.isNotBlank(namespaceURI) && !EPCIS.PROTECTED_NAMESPACE_URIS.contains(namespaceURI)) {
+        nsContext.populateDocumentNamespaces(namespaceURI, namespacePrefix);
+      }
+    });
   }
 
   /**
@@ -180,36 +158,24 @@ public abstract class XMLEventParser {
     if (nsContext == null) {
       return;
     }
-
-    IntStream.range(0, xmlStreamReader.getNamespaceCount())
-            .forEach(
-                    namespaceIndex -> {
-                      final String namespacePrefix = xmlStreamReader.getNamespacePrefix(namespaceIndex);
-                      final String namespaceURI = xmlStreamReader.getNamespaceURI(namespaceIndex);
-                      // Only capture non-standard namespaces as event-level
-                      if (StringUtils.isNotBlank(namespacePrefix)
-                              && StringUtils.isNotBlank(namespaceURI)
-                              && !EPCIS.EPCIS_DEFAULT_NAMESPACES.containsKey(namespacePrefix)
-                              && !EPCIS.XSI.equals(namespacePrefix)) {
-                        nsContext.populateEventNamespaces(namespaceURI, namespacePrefix);
-                      }
-                    });
+    IntStream.range(0, xmlStreamReader.getNamespaceCount()).forEach(namespaceIndex -> {
+      final String namespacePrefix = xmlStreamReader.getNamespacePrefix(namespaceIndex);
+      final String namespaceURI = xmlStreamReader.getNamespaceURI(namespaceIndex);
+      // Only capture non-standard namespaces as event-level
+      if (StringUtils.isNotBlank(namespacePrefix) && StringUtils.isNotBlank(namespaceURI) && !EPCIS.EPCIS_DEFAULT_NAMESPACES.containsKey(namespacePrefix) && !EPCIS.XSI.equals(namespacePrefix)) {
+        nsContext.populateEventNamespaces(namespaceURI, namespacePrefix);
+      }
+    });
   }
 
-  protected void prepareContextAttributes(
-      Map<String, String> contextAttributes, XMLStreamReader xmlStreamReader) {
-    IntStream.range(0, xmlStreamReader.getAttributeCount())
-        .forEach(
-            attributeIndex -> {
-              // Omit the attribute values which are already present within JSON-LD Schema
-              // by
-              // default
-              if (!EPCIS.PROTECTED_TERMS_OF_CONTEXT.contains(xmlStreamReader.getAttributeName(attributeIndex))) {
-                contextAttributes.put(
-                        String.valueOf(xmlStreamReader.getAttributeName(attributeIndex)),
-                    xmlStreamReader.getAttributeValue(attributeIndex)
-                );
-              }
-            });
+  protected void prepareContextAttributes(Map<String, String> contextAttributes, XMLStreamReader xmlStreamReader) {
+    IntStream.range(0, xmlStreamReader.getAttributeCount()).forEach(attributeIndex -> {
+      // Omit the attribute values which are already present within JSON-LD Schema
+      // by
+      // default
+      if (!EPCIS.PROTECTED_TERMS_OF_CONTEXT.contains(xmlStreamReader.getAttributeName(attributeIndex))) {
+        contextAttributes.put(String.valueOf(xmlStreamReader.getAttributeName(attributeIndex)), xmlStreamReader.getAttributeValue(attributeIndex));
+      }
+    });
   }
 }

--- a/core/src/main/java/io/openepcis/converter/xml/XmlToJsonConverter.java
+++ b/core/src/main/java/io/openepcis/converter/xml/XmlToJsonConverter.java
@@ -41,7 +41,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-import lombok.extern.slf4j.Slf4j;
 import org.eclipse.persistence.jaxb.JAXBContextProperties;
 
 /**
@@ -50,16 +49,9 @@ import org.eclipse.persistence.jaxb.JAXBContextProperties;
  * to JSON converter for EPCIS events. Do not share an instance across threads. EventsConverter:
  * Public method that will be called by client during the conversions.
  */
-@Slf4j
 public class XmlToJsonConverter extends XMLEventParser implements EventsConverter {
-
   // Jackson instance to convert the unmarshalled event to JSON
-  private final ObjectMapper objectMapper =
-      new ObjectMapper()
-          .registerModule(new JavaTimeModule())
-          .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-          .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-          .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+  private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule()).configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false).setSerializationInclusion(JsonInclude.Include.NON_NULL).setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 
   public XmlToJsonConverter(final JAXBContext jaxbContext, final ConversionNamespaceContext nsContext) {
     super(jaxbContext, nsContext);
@@ -69,24 +61,17 @@ public class XmlToJsonConverter extends XMLEventParser implements EventsConverte
     this(jaxbContext, new ConversionNamespaceContext());
   }
 
-  private XmlToJsonConverter(
-      final XmlToJsonConverter parent, BiFunction<Object, List<Object>, Object> epcisEventMapper) {
+  private XmlToJsonConverter(final XmlToJsonConverter parent, BiFunction<Object, List<Object>, Object> epcisEventMapper) {
     this(parent.jaxbContext, parent.nsContext);
     this.epcisEventMapper = Optional.ofNullable(epcisEventMapper);
   }
 
   public XmlToJsonConverter() throws JAXBException {
-    this(
-        JAXBContext.newInstance(
-            "io.openepcis.model.epcis",
-            Thread.currentThread().getContextClassLoader(),
-            new HashMap<>() {
-              {
-                put(
-                    JAXBContextProperties.NAMESPACE_PREFIX_MAPPER,
-                    new EPCISNamespacePrefixMapper());
-              }
-            }));
+    this(JAXBContext.newInstance("io.openepcis.model.epcis", Thread.currentThread().getContextClassLoader(), new HashMap<>() {
+      {
+        put(JAXBContextProperties.NAMESPACE_PREFIX_MAPPER, new EPCISNamespacePrefixMapper());
+      }
+    }));
   }
 
   /**
@@ -101,9 +86,7 @@ public class XmlToJsonConverter extends XMLEventParser implements EventsConverte
    * @throws IOException Method throws IOException when error occurred during the conversion.
    */
   @Override
-  public void convert(
-      InputStream xmlStream, EventHandler<? extends EPCISEventCollector> eventHandler)
-      throws IOException, XMLStreamException, JAXBException {
+  public void convert(InputStream xmlStream, EventHandler<? extends EPCISEventCollector> eventHandler) throws IOException, XMLStreamException, JAXBException {
     convert(xmlStream, eventHandler, this.jaxbContext);
   }
 
@@ -120,67 +103,46 @@ public class XmlToJsonConverter extends XMLEventParser implements EventsConverte
    * @throws IOException Method throws IOException when error occurred during the conversion.
    */
   @Override
-  public void convert(
-      InputStream xmlStream,
-      EventHandler<? extends EPCISEventCollector> eventHandler,
-      JAXBContext jaxbContext)
-      throws IOException, XMLStreamException, JAXBException {
-
+  public void convert(InputStream xmlStream, EventHandler<? extends EPCISEventCollector> eventHandler, JAXBContext jaxbContext) throws IOException, XMLStreamException, JAXBException {
     try {
       // Check if InputStream has some content if not then throw appropriate Exception
       validateXmlStrem(xmlStream);
-
       // Variable to ensure whether provided InputStream is EPCIS document or single event
       boolean isDocument = false;
-
       // Clear the namespaces before reading the document
       nsContext.resetAllNamespaces();
-
       // Map to store the attributes from the XML Header so can be added to final JSON
       final Map<String, String> contextAttributes = new HashMap<>();
-
       // Track event sequence
       final AtomicInteger sequenceInEventList = new AtomicInteger(0);
-
       // Create an instance of XMLStreamReader to read the events one-by-one
       final XMLStreamReader xmlStreamReader = createXmlStreamReader(xmlStream);
-
       // Create an instance of JAXBContext and Unmarshaller for unmarshalling the classes to
       // respective event
       final Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
       // Inject namespace context into CustomExtensionAdapter for ILMD inline namespace discovery
       unmarshaller.setAdapter(CustomExtensionAdapter.class, new CustomExtensionAdapter(nsContext));
-
       // Throw exception if invalid values are found during unmarshalling the XML
       validateXmlEvent(unmarshaller);
-
       // To format the JSON event after conversion
       objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
-
       // Navigate to next and start of the XML Elements
       xmlStreamReader.next();
-
       // Read Until the end of the file and unmarshall event-by-event
       boolean ended = false;
       while (xmlStreamReader.hasNext()) {
-
-        if(xmlStreamReader.isStartElement()){
+        if (xmlStreamReader.isStartElement()) {
           final String name = xmlStreamReader.getLocalName();
-
           // Check if the initial element is one of the elements from "EVENT_TYPES" (one of EPCIS event)
           if (EPCIS.EPCIS_EVENT_TYPES.contains(name)) {
-
             // Capture event-level namespaces before unmarshalling
             prepareEventNamespaces(xmlStreamReader);
-
             // Get the event type
             Object event = getEvent(xmlStreamReader, unmarshaller);
-
             // Check if Object has some value
             if (event != null) {
               // map event
               event = applyEventMapper(sequenceInEventList, event);
-
               // Create the JSON using Jackson ObjectMapper based on type of incoming event type and store
               // Pass namespace context to allow CustomContextSerializer to access namespaces
               ObjectWriter writer = objectMapper.writerWithDefaultPrettyPrinter();
@@ -188,7 +150,6 @@ public class XmlToJsonConverter extends XMLEventParser implements EventsConverte
                 writer = writer.withAttribute(ConversionNamespaceContext.ATTR_KEY, nsContext);
               }
               final String eventAsJson = writer.writeValueAsString(event);
-
               // If the provided XML is EPCIS document then add the converted event to Collectors List and proceed to next event
               if (isDocument) {
                 // Call the method to check if the event adheres to JSON-Schema or write into the OutputStream using the EventHandler
@@ -201,11 +162,9 @@ public class XmlToJsonConverter extends XMLEventParser implements EventsConverte
                 return;
               }
             }
-
             // Directly proceed without going to xmlStreamReader.next to avoid skipping the next event.
             continue;
           } else {
-
             // For EPCISQueryDocument set SubscriptionID and QueryName for XML writing
             if (!eventHandler.isEPCISDocument()) {
               if (xmlStreamReader.getLocalName().equalsIgnoreCase(EPCIS.SUBSCRIPTION_ID)) {
@@ -217,49 +176,39 @@ public class XmlToJsonConverter extends XMLEventParser implements EventsConverte
                 eventHandler.start(contextAttributes);
               }
             }
-
             if (name.toLowerCase().contains(EPCIS.DOCUMENT.toLowerCase())) {
               // Get the information related to the XML header elements till "EventList", If the element is EPCISDocument get all namespaces
-
               // Set the variable to true if the provided XML is EPCIS document else set to false for single EPCIS event
               isDocument = true;
               final boolean doc = name.equalsIgnoreCase(EPCIS.EPCIS_DOCUMENT);
-
               // Set for EPCISDocument or EPCISQueryDocument for adding the header elements
               eventHandler.setIsEPCISDocument(doc);
-
               // Get all Namespaces from the XML header and store it within the xmlNamespaces MAP
               prepareNameSpaces(xmlStreamReader);
-
               // Get all the Attributes from XML header and store it within attributes MAP for creation of final JSON
               prepareContextAttributes(contextAttributes, xmlStreamReader);
-
               // For EPCISDocument invoke EventHandle Start to create the header information at EPCISDocument
               if (doc) {
                 eventHandler.start(contextAttributes);
               }
             }
           }
-        } else if(xmlStreamReader.isEndElement()){
+        } else if (xmlStreamReader.isEndElement()) {
           // Call the EventHandle End method to end all the header objects created in the Start method.
           final String name = xmlStreamReader.getLocalName();
-
-          if(name.equalsIgnoreCase(EPCIS.EPCIS_DOCUMENT)){
+          if (name.equalsIgnoreCase(EPCIS.EPCIS_DOCUMENT)) {
             eventHandler.end();
             ended = true;
             break;
           }
         }
-
         // always advance to next
         xmlStreamReader.next();
       }
-
       // Call the EventHandle End method in case </EPCISDocument> never explicitly fired above
       if (!ended) {
         eventHandler.end();
       }
-
     } catch (Exception e) {
       eventHandler.fail(e);
       throw new FormatConverterException("XML to JSON/JSON-LD conversion failed, " + e.getMessage(), e);

--- a/service/converter-service-rest/src/main/java/io/openepcis/epc/converter/exception/ExceptionMapper.java
+++ b/service/converter-service-rest/src/main/java/io/openepcis/epc/converter/exception/ExceptionMapper.java
@@ -17,29 +17,22 @@ package io.openepcis.epc.converter.exception;
 
 import io.openepcis.converter.exception.FormatConverterException;
 import io.openepcis.model.rest.ProblemResponseBody;
-import lombok.extern.slf4j.Slf4j;
 import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 
-@Slf4j
 public class ExceptionMapper {
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ExceptionMapper.class);
 
   @ServerExceptionMapper
   public final RestResponse<ProblemResponseBody> mapException(final FormatConverterException exception) {
     log.error(exception.getMessage(), exception);
-
     // Build detailed message including root cause for better error diagnostics
     final String rootCauseMsg = getRootCauseMessage(exception);
     String detailMessage = exception.getMessage();
     if (!rootCauseMsg.equals(exception.getMessage())) {
       detailMessage = detailMessage + " [Root cause: " + rootCauseMsg + "]";
     }
-
-    ProblemResponseBody responseBody = new ProblemResponseBody()
-        .type(exception.getClass().getSimpleName())
-        .title("Bad Request")
-        .status(RestResponse.Status.BAD_REQUEST.getStatusCode())
-        .detail(detailMessage);
+    ProblemResponseBody responseBody = new ProblemResponseBody().type(exception.getClass().getSimpleName()).title("Bad Request").status(RestResponse.Status.BAD_REQUEST.getStatusCode()).detail(detailMessage);
     return RestResponse.status(RestResponse.Status.BAD_REQUEST, responseBody);
   }
 

--- a/service/quarkus-converter-service/src/main/java/io/openepcis/epc/converter/RESTApplication.java
+++ b/service/quarkus-converter-service/src/main/java/io/openepcis/epc/converter/RESTApplication.java
@@ -22,12 +22,10 @@ import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 import jakarta.xml.bind.JAXBException;
 import javax.xml.namespace.QName;
-import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 
 @ApplicationPath("/")
 @RegisterForReflection(targets = {QName.class, JAXBException.class})
-@Slf4j
 public class RESTApplication extends Application {
 
   @Route(methods = Route.HttpMethod.GET, path = "/")


### PR DESCRIPTION
Part of moving the OpenEPCIS build to Java 25 / Quarkus 3.33 LTS.

**Heads-up for consumers:** the build target moves from Java 21 to 25, so artifacts produced from this branch cannot be consumed by projects still building on JDK 21.

Fast-forward — `main` is a strict ancestor of this branch, so there is nothing to merge and nothing that can conflict.

Lombok is removed in favour of explicit accessors, constructors and SLF4J loggers. A `javap -p` API diff per module was used to prove no accessor, constructor or builder method changed signature; the only differences anywhere were dead logger fields that were deleted rather than replaced.

Verified as part of the aggregate build: `-Pquarkus-rest` gives BUILD SUCCESS with 0 compile errors over 58 reactor entries.